### PR TITLE
Example config: httpd does not need Shibboleth secrets

### DIFF
--- a/EXAMPLE_CONFIG.md
+++ b/EXAMPLE_CONFIG.md
@@ -226,9 +226,6 @@ spec:
               protocol: TCP
           image: quay.io/tike/openshift-sp-httpd:latest
           volumeMounts:
-            - name: shib-secrets
-              mountPath: /shib-secrets
-              readOnly: true
             - name: shib-config
               mountPath: /shib-config
               readOnly: true


### PR DESCRIPTION
These credentials are used between the SP (shibd) and the IDP.
The http daemon does not need them for operation, so they
should not be exposed to the httpd container.